### PR TITLE
NXP-29032: move the required field icon to parent

### DIFF
--- a/nuxeo-retention-web/document/retentionrule/nuxeo-retentionrule-create-layout.html
+++ b/nuxeo-retention-web/document/retentionrule/nuxeo-retentionrule-create-layout.html
@@ -22,7 +22,18 @@ limitations under the License.
 -->
 <dom-module id="nuxeo-retentionrule-create-layout">
   <template>
-    <style include="iron-flex iron-flex-alignment nuxeo-styles"></style>
+    <style include="iron-flex iron-flex-alignment nuxeo-styles">
+      .retentionDuration {
+        margin-bottom: 8px;
+      }
+
+      .retentionDuration::after {
+        display: inline-block;
+        content: '*';
+        margin-left: 4px;
+        color: var(--paper-input-container-invalid-color, #de350b);
+      }
+    </style>
 
     <nuxeo-input
       role="widget"
@@ -156,6 +167,7 @@ limitations under the License.
     </nuxeo-card>
 
     <nuxeo-card heading="[[i18n('retention.rule.label.duration.heading')]]">
+      <div class="retentionDuration">[[i18n('retention.rule.label.duration.subHeading')]]</div>
       <div class="layout horizontal justified flex">
         <nuxeo-input
           role="widget"
@@ -163,7 +175,6 @@ limitations under the License.
           value="{{document.properties.retention_def:durationYears}}"
           label="[[i18n('retention.rule.label.duration.years')]]"
           min="0"
-          required
           type="number"
         >
         </nuxeo-input>
@@ -173,7 +184,6 @@ limitations under the License.
           value="{{document.properties.retention_def:durationMonths}}"
           label="[[i18n('retention.rule.label.duration.months')]]"
           min="0"
-          required
           type="number"
         >
         </nuxeo-input>
@@ -183,7 +193,6 @@ limitations under the License.
           value="{{document.properties.retention_def:durationDays}}"
           label="[[i18n('retention.rule.label.duration.days')]]"
           min="0"
-          required
           type="number"
         >
         </nuxeo-input>

--- a/nuxeo-retention-web/document/retentionrule/nuxeo-retentionrule-edit-layout.html
+++ b/nuxeo-retention-web/document/retentionrule/nuxeo-retentionrule-edit-layout.html
@@ -22,7 +22,18 @@ limitations under the License.
 -->
 <dom-module id="nuxeo-retentionrule-edit-layout">
   <template>
-    <style include="iron-flex iron-flex-alignment nuxeo-styles"></style>
+    <style include="iron-flex iron-flex-alignment nuxeo-styles">
+      .retentionDuration {
+        margin-bottom: 8px;
+      }
+
+      .retentionDuration::after {
+        display: inline-block;
+        content: '*';
+        margin-left: 4px;
+        color: var(--paper-input-container-invalid-color, #de350b);
+      }
+    </style>
 
     <nuxeo-input
       role="widget"
@@ -156,6 +167,7 @@ limitations under the License.
     </nuxeo-card>
 
     <nuxeo-card heading="[[i18n('retention.rule.label.duration.heading')]]">
+      <div class="retentionDuration">[[i18n('retention.rule.label.duration.subHeading')]]</div>
       <div class="layout horizontal justified flex">
         <nuxeo-input
           role="widget"
@@ -163,7 +175,6 @@ limitations under the License.
           value="{{document.properties.retention_def:durationYears}}"
           label="[[i18n('retention.rule.label.duration.years')]]"
           min="0"
-          required
           type="number"
         >
         </nuxeo-input>
@@ -173,7 +184,6 @@ limitations under the License.
           value="{{document.properties.retention_def:durationMonths}}"
           label="[[i18n('retention.rule.label.duration.months')]]"
           min="0"
-          required
           type="number"
         >
         </nuxeo-input>
@@ -183,7 +193,6 @@ limitations under the License.
           value="{{document.properties.retention_def:durationDays}}"
           label="[[i18n('retention.rule.label.duration.days')]]"
           min="0"
-          required
           type="number"
         >
         </nuxeo-input>

--- a/nuxeo-retention-web/i18n/messages.json
+++ b/nuxeo-retention-web/i18n/messages.json
@@ -67,6 +67,7 @@
   "retention.rule.label.applicationPolicy.docTypes.placeholder": "Select document types",
   "retention.rule.label.applicationPolicy.placehodler": "Select the policy",
   "retention.rule.label.duration.heading": "Retention duration",
+  "retention.rule.label.duration.subHeading": "Select a duration",
   "retention.rule.label.duration.years": "Years",
   "retention.rule.label.duration.months": "Months",
   "retention.rule.label.duration.days": "Days",


### PR DESCRIPTION
Since we only need the ensemble to be required, move the symbol to a subtitle (title is controlled by nuxeo-card so it's complicated). The validation logic still higlights fields if left empty.

<img width="937" alt="Screen Shot 2021-02-15 at 14 09 25" src="https://user-images.githubusercontent.com/8356441/107951289-667b4980-6f98-11eb-983b-97a659379fbe.png">
<img width="994" alt="Screen Shot 2021-02-15 at 14 09 08" src="https://user-images.githubusercontent.com/8356441/107951297-68450d00-6f98-11eb-9167-944ea7a0c543.png">
