### PR TITLE
NXP-33198: Fix node label for release pipeline

### DIFF
--- a/ci/Jenkinsfiles/release.groovy
+++ b/ci/Jenkinsfiles/release.groovy
@@ -23,7 +23,7 @@ library identifier: "platform-ci-shared-library@v0.0.75"
 
 pipeline {
   agent {
-    label 'jenkins-nuxeo-package-lts-2023-nodejs18'
+    label 'jenkins-nuxeo-package-lts-2023'
   }
   options {
     buildDiscarder(logRotator(daysToKeepStr: '60', numToKeepStr: '60', artifactNumToKeepStr: '5'))


### PR DESCRIPTION
I figured out I missed this diff while doing https://github.com/nuxeo/nuxeo-retention/commit/8c532079ab29646f53cbf65a9063589d85c93803

As a direct result, the release job hangs with:
```
[2025-12-01T15:26:29.131Z] There are no nodes with the label ‘jenkins-nuxeo-package-lts-2023-nodejs18’
```
https://jenkins.platform.dev.nuxeo.com/blue/organizations/jenkins/retention%2Frelease-nuxeo-retention/detail/release-nuxeo-retention/14/pipeline/