### PR TITLE
Revert "NXP-33683: disable retention ftests blocked by WebUI 2025.16.0 selector regression"

### DIFF
--- a/nuxeo-retention-web/ftest/features/retention.feature
+++ b/nuxeo-retention-web/ftest/features/retention.feature
@@ -16,9 +16,6 @@ Feature: Retention
     When I login as "John"
     Then I can see the retention menu
 
-  # NXP-33683: Disabled until WebUI fixes DocumentView selector regression in 2025.16.0
-  # See https://github.com/nuxeo/nuxeo-web-ui/blob/666fbebd016847eb4c3a4e/packages/nuxeo-web-ui-ftest/pages/ui/browser/document_page.js
-  @ignore
   Scenario: Immediate Manual Rule
     When I login as "John"
     And I go to the retention rules location
@@ -38,8 +35,6 @@ Feature: Retention
     Then I see the document is under retention
     And I cannot edit main blob
 
-  # NXP-33683: Disabled until WebUI fixes DocumentView selector regression in 2025.16.0
-  @ignore
   Scenario: Metadata-based Manual Rule
     When I login as "John"
     And I go to the retention rules location
@@ -63,8 +58,6 @@ Feature: Retention
     Then I see the document is under retention
     And I cannot edit main blob
 
-  # NXP-33683: Disabled until WebUI fixes DocumentView selector regression in 2025.16.0
-  @ignore
   Scenario: Event-based Manual Rule
     Given I have a "ContractEnd" retention event
     When I login as "John"

--- a/nuxeo-retention-web/package.json
+++ b/nuxeo-retention-web/package.json
@@ -72,7 +72,7 @@
     "format": "npm run format:prettier && npm run format:eslint",
     "format:eslint": "eslint --ext .js,.html . --fix",
     "format:prettier": "prettier \"**/*.{js,html}\" --write",
-    "ftest": "cd ftest && nuxeo-web-ui-ftest --screenshots --report --headless --tags=\"not @ignore\"",
+    "ftest": "cd ftest && nuxeo-web-ui-ftest --screenshots --report --headless",
     "ftest:watch": "cd ftest && nuxeo-web-ui-ftest --debug --tags=@watch",
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch"


### PR DESCRIPTION
This reverts commit db3c6b0e3047f4e41044401c0b544b99b53d8bc3.
