### PR TITLE
[DO NOT MERGE][test] retention ftests vs web-ui PR #3333 ftest (lts-2025)

### DIFF
--- a/ci/Jenkinsfiles/build.groovy
+++ b/ci/Jenkinsfiles/build.groovy
@@ -237,6 +237,21 @@ pipeline {
               nxWithHelmfileDeployment(namespace: testNamespace, environment: "functionalTests", envVars: ["CONNECT_CLID_SECRET=${clidSecret}"],
                   secrets: [[name: clidSecret, namespace: 'platform']]) {
                 dir('nuxeo-retention-web') {
+                  // [DO NOT MERGE] Overlay the @nuxeo/nuxeo-web-ui-ftest source from
+                  // nuxeo-web-ui PR #3333 (test-side only changes) on top of the released
+                  // package installed by `npm ci`, keeping its node_modules and manifests
+                  // intact (single dependency tree). This validates the unreleased ftest
+                  // changes against the retention scenarios.
+                  sh '''
+                      set -eu
+                      WEBUI_FTEST_BRANCH=ftest-wdio-browser-provisioning-optimization-lts-2025
+                      rm -rf /tmp/nuxeo-web-ui-ftest-pr
+                      git clone --depth 1 --branch "${WEBUI_FTEST_BRANCH}" \
+                        https://github.com/nuxeo/nuxeo-web-ui.git /tmp/nuxeo-web-ui-ftest-pr
+                      ( cd /tmp/nuxeo-web-ui-ftest-pr/packages/nuxeo-web-ui-ftest \
+                        && tar --exclude=node_modules --exclude=package.json --exclude=package-lock.json -cf - . ) \
+                      | ( cd node_modules/@nuxeo/nuxeo-web-ui-ftest && tar -xf - )
+                    '''
                   sh """
                       mvn ${MAVEN_CLI_ARGS} com.github.eirslett:frontend-maven-plugin:npm@ftest -Pftest \
                       -Dfrontend-plugin.ftest.nuxeoUrl=http://nuxeo.${NAMESPACE}.svc.cluster.local/nuxeo

--- a/nuxeo-retention-web/ftest/features/retention.feature
+++ b/nuxeo-retention-web/ftest/features/retention.feature
@@ -16,9 +16,6 @@ Feature: Retention
     When I login as "John"
     Then I can see the retention menu
 
-  # NXP-33683: Disabled until WebUI fixes DocumentView selector regression in 2025.16.0
-  # See https://github.com/nuxeo/nuxeo-web-ui/blob/666fbebd016847eb4c3a4e/packages/nuxeo-web-ui-ftest/pages/ui/browser/document_page.js
-  @ignore
   Scenario: Immediate Manual Rule
     When I login as "John"
     And I go to the retention rules location
@@ -38,8 +35,6 @@ Feature: Retention
     Then I see the document is under retention
     And I cannot edit main blob
 
-  # NXP-33683: Disabled until WebUI fixes DocumentView selector regression in 2025.16.0
-  @ignore
   Scenario: Metadata-based Manual Rule
     When I login as "John"
     And I go to the retention rules location
@@ -63,8 +58,6 @@ Feature: Retention
     Then I see the document is under retention
     And I cannot edit main blob
 
-  # NXP-33683: Disabled until WebUI fixes DocumentView selector regression in 2025.16.0
-  @ignore
   Scenario: Event-based Manual Rule
     Given I have a "ContractEnd" retention event
     When I login as "John"

--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -221,18 +221,43 @@ When('I clear the search filters', async function () {
 });
 
 Then('I can see {int} document in search results', async function (results) {
-  await driver.pause(2000);
   const ui = await this.ui;
   const searchPage = await ui.el.element('nuxeo-search-page#retentionSearch');
   await searchPage.waitForVisible();
-  const ele = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+  // Read the count label via textContent (which pierces shadow DOM): on Chrome 150+ getText()
+  // returns '' for shadow-DOM content that is not laid out on screen. Re-query the label each poll
+  // to avoid stale-element errors when the results re-render, and wait/retry to cover Elasticsearch
+  // indexing lag instead of a single fixed pause.
+  const readCount = async () => {
+    const el = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+    if (!(await el.isExisting()) || !(await el.isVisible())) {
+      return null;
+    }
+    return ((await driver.execute((node) => node.textContent, el)) || '').trim();
+  };
   if (results === 0) {
-    return !ele.isVisible();
+    await driver.waitUntil(async () => (await readCount()) === null, {
+      timeout: 20000,
+      interval: 1000,
+      timeoutMsg: 'Expected no results but the count label is still shown',
+    });
+    return true;
   }
-  const text = await ele.getText();
-  if (text !== `${results} result(s)`) {
-    throw new Error(`Expected count of ${results} but found ${text}`);
-  }
+  let lastSeen = 'n/a';
+  await driver
+    .waitUntil(
+      async () => {
+        const text = await readCount();
+        if (text !== null) {
+          lastSeen = text;
+        }
+        return text === `${results} result(s)`;
+      },
+      { timeout: 20000, interval: 1000 },
+    )
+    .catch(() => {
+      throw new Error(`Expected count of ${results} but found ${lastSeen}`);
+    });
   return true;
 });
 

--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -127,7 +127,10 @@ Then('I attach the {string} rule to the document', async function (ruleName) {
   await fixtures.layouts.setValue(select, ruleName);
   const addButton = await dialog.element('paper-button[name="add"]');
   await addButton.waitForEnabled();
-  await addButton.click();
+  // The nuxeo-document-suggestion element's bounding box extends over the button after selection,
+  // causing WebDriver's W3C hit-test to report 'element click intercepted'. Use a JavaScript
+  // click to dispatch the event directly on the button, bypassing the hit-test.
+  await driver.execute((el) => el.click(), addButton);
   await driver.waitForVisible('iron-overlay-backdrop', 5000, true);
 });
 

--- a/nuxeo-retention-web/package.json
+++ b/nuxeo-retention-web/package.json
@@ -72,7 +72,7 @@
     "format": "npm run format:prettier && npm run format:eslint",
     "format:eslint": "eslint --ext .js,.html . --fix",
     "format:prettier": "prettier \"**/*.{js,html}\" --write",
-    "ftest": "cd ftest && nuxeo-web-ui-ftest --screenshots --report --headless --tags=\"not @ignore\"",
+    "ftest": "cd ftest && nuxeo-web-ui-ftest --screenshots --report --headless",
     "ftest:watch": "cd ftest && nuxeo-web-ui-ftest --debug --tags=@watch",
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch"


### PR DESCRIPTION
## Purpose (do not merge)

Test-only PR to exercise the `retention.js` search-count polling change against the **unreleased** ftest from nuxeo-web-ui PR nuxeo/nuxeo-web-ui#3333 (lts-2025 line) in CI.

## Changes
- `test(ftest)`: search-count polling refinement (same as the released-ftest companion PR).
- `ci` **[DO NOT MERGE]**: in the ftest stage, overlay the `@nuxeo/nuxeo-web-ui-ftest` source from PR #3333's branch (`ftest-wdio-browser-provisioning-optimization-lts-2025`) on top of the released package installed by `npm ci`, keeping its `node_modules` and manifests intact (single dependency tree). PR #3333 is test-side only, so the released web-ui server image is unchanged.

## Scenario
2 of 2 — **PR ftest**. The companion PR tests the same change against released ftest.

Do not merge — for CI signal only.