### PR TITLE
[DO NOT MERGE][test] retention ftests vs web-ui PR #3315 ftest (lts-2023)

### DIFF
--- a/ci/Jenkinsfiles/build.groovy
+++ b/ci/Jenkinsfiles/build.groovy
@@ -194,6 +194,21 @@ pipeline {
               nxWithHelmfileDeployment(namespace: testNamespace, environment: "functionalTests", envVars: ["CONNECT_CLID_SECRET=${clidSecret}"],
                   secrets: [[name: clidSecret, namespace: 'platform']]) {
                 dir('nuxeo-retention-web') {
+                  // [DO NOT MERGE] Overlay the @nuxeo/nuxeo-web-ui-ftest source from
+                  // nuxeo-web-ui PR #3315 (test-side only changes) on top of the released
+                  // package installed by `npm ci`, keeping its node_modules and manifests
+                  // intact (single dependency tree). This validates the unreleased ftest
+                  // changes against the retention scenarios.
+                  sh '''
+                      set -eu
+                      WEBUI_FTEST_BRANCH=ftest-wdio-browser-provisioning-optimization
+                      rm -rf /tmp/nuxeo-web-ui-ftest-pr
+                      git clone --depth 1 --branch "${WEBUI_FTEST_BRANCH}" \
+                        https://github.com/nuxeo/nuxeo-web-ui.git /tmp/nuxeo-web-ui-ftest-pr
+                      ( cd /tmp/nuxeo-web-ui-ftest-pr/packages/nuxeo-web-ui-ftest \
+                        && tar --exclude=node_modules --exclude=package.json --exclude=package-lock.json -cf - . ) \
+                      | ( cd node_modules/@nuxeo/nuxeo-web-ui-ftest && tar -xf - )
+                    '''
                   sh """
                       mvn -B -nsu com.github.eirslett:frontend-maven-plugin:npm@ftest -Pftest \
                       -Dfrontend-plugin.ftest.nuxeoUrl=http://nuxeo.${NAMESPACE}.svc.cluster.local/nuxeo

--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -221,18 +221,43 @@ When('I clear the search filters', async function () {
 });
 
 Then('I can see {int} document in search results', async function (results) {
-  await driver.pause(2000);
   const ui = await this.ui;
   const searchPage = await ui.el.element('nuxeo-search-page#retentionSearch');
   await searchPage.waitForVisible();
-  const ele = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+  // Read the count label via textContent (which pierces shadow DOM): on Chrome 150+ getText()
+  // returns '' for shadow-DOM content that is not laid out on screen. Re-query the label each poll
+  // to avoid stale-element errors when the results re-render, and wait/retry to cover Elasticsearch
+  // indexing lag instead of a single fixed pause.
+  const readCount = async () => {
+    const el = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+    if (!(await el.isExisting()) || !(await el.isVisible())) {
+      return null;
+    }
+    return ((await driver.execute((node) => node.textContent, el)) || '').trim();
+  };
   if (results === 0) {
-    return !ele.isVisible();
+    await driver.waitUntil(async () => (await readCount()) === null, {
+      timeout: 20000,
+      interval: 1000,
+      timeoutMsg: 'Expected no results but the count label is still shown',
+    });
+    return true;
   }
-  const text = await ele.getText();
-  if (text !== `${results} result(s)`) {
-    throw new Error(`Expected count of ${results} but found ${text}`);
-  }
+  let lastSeen = 'n/a';
+  await driver
+    .waitUntil(
+      async () => {
+        const text = await readCount();
+        if (text !== null) {
+          lastSeen = text;
+        }
+        return text === `${results} result(s)`;
+      },
+      { timeout: 20000, interval: 1000 },
+    )
+    .catch(() => {
+      throw new Error(`Expected count of ${results} but found ${lastSeen}`);
+    });
   return true;
 });
 

--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -127,7 +127,10 @@ Then('I attach the {string} rule to the document', async function (ruleName) {
   await fixtures.layouts.setValue(select, ruleName);
   const addButton = await dialog.element('paper-button[name="add"]');
   await addButton.waitForEnabled();
-  await addButton.click();
+  // The nuxeo-document-suggestion element's bounding box extends over the button after selection,
+  // causing WebDriver's W3C hit-test to report 'element click intercepted'. Use a JavaScript
+  // click to dispatch the event directly on the button, bypassing the hit-test.
+  await driver.execute((el) => el.click(), addButton);
   await driver.waitForVisible('iron-overlay-backdrop', 5000, true);
 });
 


### PR DESCRIPTION
## Purpose (do not merge)

Test-only PR to exercise the `retention.js` search-count polling change against the **unreleased** ftest from nuxeo-web-ui PR nuxeo/nuxeo-web-ui#3315 (maintenance-3.1.x / LTS-2023 line) in CI.

## Changes
- `test(ftest)`: search-count polling refinement (same as the released-ftest companion PR).
- `ci` **[DO NOT MERGE]**: in the ftest stage, overlay the `@nuxeo/nuxeo-web-ui-ftest` source from PR #3315's branch (`ftest-wdio-browser-provisioning-optimization`) on top of the released package installed by `npm ci`, keeping its `node_modules` and manifests intact (single dependency tree). PR #3315 is test-side only, so the released web-ui server image is unchanged.

## Scenario
2 of 2 — **PR ftest** (LTS-2023). The companion PR tests the same change against released ftest.

Do not merge — for CI signal only.