### PR TITLE
[DO NOT MERGE][test] retention ftests vs released web-ui ftest (lts-2023)

### DIFF
--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -221,18 +221,43 @@ When('I clear the search filters', async function () {
 });
 
 Then('I can see {int} document in search results', async function (results) {
-  await driver.pause(2000);
   const ui = await this.ui;
   const searchPage = await ui.el.element('nuxeo-search-page#retentionSearch');
   await searchPage.waitForVisible();
-  const ele = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+  // Read the count label via textContent (which pierces shadow DOM): on Chrome 150+ getText()
+  // returns '' for shadow-DOM content that is not laid out on screen. Re-query the label each poll
+  // to avoid stale-element errors when the results re-render, and wait/retry to cover Elasticsearch
+  // indexing lag instead of a single fixed pause.
+  const readCount = async () => {
+    const el = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+    if (!(await el.isExisting()) || !(await el.isVisible())) {
+      return null;
+    }
+    return ((await driver.execute((node) => node.textContent, el)) || '').trim();
+  };
   if (results === 0) {
-    return !ele.isVisible();
+    await driver.waitUntil(async () => (await readCount()) === null, {
+      timeout: 20000,
+      interval: 1000,
+      timeoutMsg: 'Expected no results but the count label is still shown',
+    });
+    return true;
   }
-  const text = await ele.getText();
-  if (text !== `${results} result(s)`) {
-    throw new Error(`Expected count of ${results} but found ${text}`);
-  }
+  let lastSeen = 'n/a';
+  await driver
+    .waitUntil(
+      async () => {
+        const text = await readCount();
+        if (text !== null) {
+          lastSeen = text;
+        }
+        return text === `${results} result(s)`;
+      },
+      { timeout: 20000, interval: 1000 },
+    )
+    .catch(() => {
+      throw new Error(`Expected count of ${results} but found ${lastSeen}`);
+    });
   return true;
 });
 

--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -127,7 +127,10 @@ Then('I attach the {string} rule to the document', async function (ruleName) {
   await fixtures.layouts.setValue(select, ruleName);
   const addButton = await dialog.element('paper-button[name="add"]');
   await addButton.waitForEnabled();
-  await addButton.click();
+  // The nuxeo-document-suggestion element's bounding box extends over the button after selection,
+  // causing WebDriver's W3C hit-test to report 'element click intercepted'. Use a JavaScript
+  // click to dispatch the event directly on the button, bypassing the hit-test.
+  await driver.execute((el) => el.click(), addButton);
   await driver.waitForVisible('iron-overlay-backdrop', 5000, true);
 });
 


### PR DESCRIPTION
## Purpose (do not merge)

Test-only PR to exercise the `retention.js` search-count polling change against the **currently released** `@nuxeo/nuxeo-web-ui-ftest` (3.1.x line) in CI.

## Changes
- `test(ftest)`: replace the fixed 2s pause + single `getText()` read in the "I can see N document in search results" step with a re-querying `waitUntil` poll that reads the count label via `textContent` (covers Elasticsearch indexing lag and shadow-DOM/stale-element issues on Chrome 150+).

## Scenario
1 of 2 — **released ftest** baseline (LTS-2023). The companion PR tests the same change against nuxeo-web-ui PR #3315's ftest branch.

Do not merge — for CI signal only.