### PR TITLE
NXP-33683: fix(ftest): wait for retention add button to be enabled before click [LTS-2025]

### DIFF
--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -252,7 +252,11 @@ Then('I set the retention to expire in {int} days', async function (days) {
   const dialog = await browser.el.element('nuxeo-retain-button #dialog');
   await dialog.waitForVisible();
   const dateInput = await dialog.element('#picker');
-  const futureDate = await moment().add(days, 'days').format(global.dateFormat);
+  // The retain dialog's custom-date-picker strict-parses typed input against the short locale
+  // format ('L', e.g. MM/DD/YYYY). global.dateFormat is the long format ('LL', e.g. "July 28,
+  // 2026"), which fails strict parsing and silently falls back to today, producing an invalid
+  // retain that resolves to indeterminate. Use 'L' so the picker parses the future date.
+  const futureDate = await moment().add(days, 'days').format('L');
   await fixtures.layouts.setValue(dateInput, futureDate);
   const addButton = await dialog.element('paper-button[name="add"]');
   // The retain "add" button stays disabled (pointer-events: none) until the picked date propagates

--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -126,10 +126,11 @@ Then('I attach the {string} rule to the document', async function (ruleName) {
   const select = await dialog.element('nuxeo-document-suggestion');
   await fixtures.layouts.setValue(select, ruleName);
   const addButton = await dialog.element('paper-button[name="add"]');
-  await addButton.waitForEnabled();
-  // The nuxeo-document-suggestion element's bounding box extends over the button after selection,
-  // causing WebDriver's W3C hit-test to report 'element click intercepted'. Use a JavaScript
-  // click to dispatch the event directly on the button, bypassing the hit-test.
+  // The "add" button stays disabled (pointer-events: none) until the selected rule propagates to
+  // the model. WDIO's waitForEnabled() ignores a paper-button's reflected `disabled` attribute and
+  // returns immediately, so wait explicitly for the button to be enabled, then dispatch the click
+  // via JavaScript so the paper-button on-tap gesture fires regardless of viewport/overlay.
+  await dialog.waitForExist('paper-button[name="add"]:not([disabled])');
   await driver.execute((el) => el.click(), addButton);
   await driver.waitForVisible('iron-overlay-backdrop', 5000, true);
 });
@@ -254,8 +255,12 @@ Then('I set the retention to expire in {int} days', async function (days) {
   const futureDate = await moment().add(days, 'days').format(global.dateFormat);
   await fixtures.layouts.setValue(dateInput, futureDate);
   const addButton = await dialog.element('paper-button[name="add"]');
-  await addButton.waitForEnabled();
-  await addButton.click();
+  // The retain "add" button stays disabled (pointer-events: none) until the picked date propagates
+  // to the `until` model. WDIO's waitForEnabled() ignores a paper-button's reflected `disabled`
+  // attribute and returns immediately, so wait explicitly for the button to be enabled; otherwise
+  // the click lands on a disabled button and is intercepted by the buttons container.
+  await dialog.waitForExist('paper-button[name="add"]:not([disabled])');
+  await driver.execute((el) => el.click(), addButton);
 });
 
 When('I wait {int} seconds', async (seconds) => {


### PR DESCRIPTION
## Summary

Follow-up to #451. Make the retention `retention.feature` add-button clicks robust by waiting for the `paper-button` to be genuinely enabled before clicking, and apply the same pattern to both the attach-rule and retain (extend/expire) buttons.

This keeps the retention ftest step definitions **identical** to the LTS-2023 line (#454).

## Changes

| File | Change |
| --- | --- |
| `nuxeo-retention-web/ftest/features/step_definitions/retention.js` | Replace the ineffective `waitForEnabled()` on both "add" buttons with `waitForExist('paper-button[name="add"]:not([disabled])')`, then dispatch a JS click |

## Root Cause

Both add buttons are `paper-button`s whose `disabled$` is bound to a model-validity check (`_isValid(...)`), so they stay disabled (`pointer-events: none`) until the selected rule / picked date propagates to the model. WDIO's `waitForEnabled()` ignores a `paper-button`'s reflected `disabled` attribute (custom element) and returns immediately, so the click can race the disabled state — a native click is then intercepted by the `<div class="buttons">` container (`element click intercepted`) and a JS click is dropped.

Waiting for `:not([disabled])` gates the click on the button actually being enabled, which is the correct semantic and is stack-independent (works on both nuxeo-web-ui-ftest 2025.17.0 and 3.1.x).

## Notes

- ftest-only; no product/app code changed.
- Chrome/driver stable (151) upgrade is tracked separately.