### PR TITLE
NXP-33858: test(ftest): harden retention search results count for Chrome stable [lts-2025]

### DIFF
--- a/nuxeo-retention-web/ftest/features/step_definitions/retention.js
+++ b/nuxeo-retention-web/ftest/features/step_definitions/retention.js
@@ -222,17 +222,34 @@ When('I clear the search filters', async function () {
 });
 
 Then('I can see {int} document in search results', async function (results) {
-  await driver.pause(2000);
   const ui = await this.ui;
   const searchPage = await ui.el.element('nuxeo-search-page#retentionSearch');
   await searchPage.waitForVisible();
-  const ele = await searchPage.element('nuxeo-retention-search-results span.resultsCount');
+  const selector = 'nuxeo-retention-search-results span.resultsCount';
   if (results === 0) {
+    const ele = await searchPage.element(selector);
     return !ele.isVisible();
   }
-  const text = await ele.getText();
-  if (text !== `${results} result(s)`) {
-    throw new Error(`Expected count of ${results} but found ${text}`);
+  // Read the count via textContent rather than getText(): on newer Chrome (stable 150/151) getText()
+  // returns an empty string for content below the fold, so a single immediate read fails spuriously.
+  // Poll the label until it renders the expected "{n} result(s)" text, tolerating the asynchronous
+  // search / Elasticsearch indexing lag that the previous fixed pause was masking.
+  const expected = `${results} result(s)`;
+  let lastSeen = 'n/a';
+  try {
+    await driver.waitUntil(
+      async () => {
+        const ele = await searchPage.element(selector);
+        if (!(await ele.isExisting())) {
+          return false;
+        }
+        lastSeen = ((await driver.execute((el) => el.textContent, ele)) || '').trim();
+        return lastSeen === expected;
+      },
+      { timeout: 20000, interval: 1000 },
+    );
+  } catch (e) {
+    throw new Error(`Expected count of "${expected}" but found "${lastSeen}"`, { cause: e });
   }
   return true;
 });


### PR DESCRIPTION
## Purpose

lts-2025 port of [#462](https://github.com/nuxeo/nuxeo-retention/pull/462). Harden the retention
`I can see {int} document in search results` step so it is robust on Chrome **`stable`** (150/151),
and confirm it still passes against the **currently released** ftest (`@nuxeo/nuxeo-web-ui-ftest`
`~2025.17.0`).

## Change

The step read `nuxeo-retention-search-results span.resultsCount` with a single `getText()` and threw
on mismatch. On Chrome stable `getText()` returns `''` for content below the fold (the same class of
bug fixed on the WebUI side in [#3333](https://github.com/nuxeo/nuxeo-web-ui/pull/3333) /
[#3315](https://github.com/nuxeo/nuxeo-web-ui/pull/3315)). It now reads via `textContent` inside a
`waitUntil` poll, which also absorbs the async search / Elasticsearch indexing lag the previous fixed
2s pause was masking. Backward-compatible with the released ftest.

The step is **byte-identical** to the lts-2023 change in #462, per the rule that `retention.js` stays
identical across the two lines.

## Validation

- Passes against the current released ftest in CI — this PR.
- Full Chrome-`stable` validation on top of the unreleased WebUI ftest (#3333) will be re-run once
  that PR is released and consumed.

## Note

Supersedes the overlapping test-only PR #458 for the count-step hardening (that one is marked
`don't merge`, is in conflict, and bundles unrelated changes with a divergent implementation).