### PR TITLE
NXP-33650: avoid NPE when end action deletes the document

### DIFF
--- a/nuxeo-retention/src/main/java/org/nuxeo/retention/adapters/Record.java
+++ b/nuxeo-retention/src/main/java/org/nuxeo/retention/adapters/Record.java
@@ -127,8 +127,23 @@ public class Record {
         document.getContextData().remove(RetentionConstants.RETENTION_CHECKER_LISTENER_IGNORE);
     }
 
+    /**
+     * @deprecated since 2025.4, use {@link #saveRetainUntil(Calendar, CoreSession)} instead
+     */
+    @Deprecated(since = "2025.4", forRemoval = true)
     public void saveRetainUntil(Calendar retainUntil) {
+        CoreSession session = document.getCoreSession();
+        if (session == null) {
+            // Detached DocumentModel: keep in-memory update and avoid NPE
+            document.setPropertyValue(RetentionConstants.RETAIN_UNTIL_PROP, retainUntil);
+            return;
+        }
+        saveRetainUntil(retainUntil, session);
+    }
+
+    public void saveRetainUntil(Calendar retainUntil, CoreSession session) {
         document.setPropertyValue(RetentionConstants.RETAIN_UNTIL_PROP, retainUntil);
+        save(session);
     }
 
     public void setRule(RetentionRule rule, CoreSession session) {

--- a/nuxeo-retention/src/main/java/org/nuxeo/retention/listeners/RetentionExpiredListener.java
+++ b/nuxeo-retention/src/main/java/org/nuxeo/retention/listeners/RetentionExpiredListener.java
@@ -63,9 +63,8 @@ public class RetentionExpiredListener implements EventListener {
         Record record = doc.getAdapter(Record.class);
         RetentionManager retentionManager = Framework.getService(RetentionManager.class);
         CoreSession session = ctx.getCoreSession();
-        record.saveRetainUntil((Calendar) docCxt.getProperty(CoreEventConstants.RETAIN_UNTIL));
+        record.saveRetainUntil((Calendar) docCxt.getProperty(CoreEventConstants.RETAIN_UNTIL), session);
         retentionManager.proceedRetentionExpired(record, session);
-        session.saveDocument(doc);
     }
 
 }

--- a/nuxeo-retention/src/test/java/org/nuxeo/retention/test/TestRetentionManager.java
+++ b/nuxeo-retention/src/test/java/org/nuxeo/retention/test/TestRetentionManager.java
@@ -90,7 +90,7 @@ public class TestRetentionManager extends RetentionTestCase {
     }
 
     @Test
-    public void testManualImmediateRuleWithDefaultOperationActions() throws InterruptedException {
+    public void testManualImmediateRuleWithTrashEndAction() throws InterruptedException {
         RetentionRule testRule = createImmediateRuleMillis(RetentionRule.ApplicationPolicy.MANUAL, 100, null,
                 List.of("Document.Trash"));
 
@@ -105,6 +105,21 @@ public class TestRetentionManager extends RetentionTestCase {
         // it has no retention anymore and trashed
         assertFalse(session.isUnderRetentionOrLegalHold(file.getRef()));
         assertTrue(file.isTrashed());
+    }
+
+    @Test
+    public void testManualImmediateRuleWithDeleteEndAction() throws InterruptedException {
+        RetentionRule testRule = createImmediateRuleMillis(RetentionRule.ApplicationPolicy.MANUAL, 100, null,
+                List.of("Document.Delete"));
+
+        file = service.attachRule(file, testRule, session);
+        assertTrue(session.isRecord(file.getRef()));
+        assertTrue(session.isUnderRetentionOrLegalHold(file.getRef()));
+
+        awaitRetentionExpiration(1000);
+
+        // document has been deleted
+        assertFalse(session.exists(file.getRef()));
     }
 
     @Test


### PR DESCRIPTION
Move saveRetainUntil before proceedRetentionExpired so the document is persisted while it still exists. A new overload saveRetainUntil(Calendar, CoreSession) is introduced that calls the internal save() helper, which suppresses side-effect listeners (DublinCore, audit, versioning, notifications) — this is intentional and desirable for a system-driven property update.

The deprecated no-session overload now guards against a null session from getCoreSession() (detached DocumentModel): it falls back to an in-memory property update without saving, preserving the previous silent behaviour rather than throwing an NPE.

A regression test covering the Document.Delete end-action path is added.